### PR TITLE
Updating PHP shorthand tags to be full PHP tags

### DIFF
--- a/templates/admin.tpl
+++ b/templates/admin.tpl
@@ -22,7 +22,7 @@
 <div class="wrap">
     <h2>Google Analytics</h2>
     <form method="post" action="options.php">
-        <? settings_fields( 'mc_google_analytics' ); ?>
+        <?php settings_fields( 'mc_google_analytics' ); ?>
 
         <table class="form-table">
             <tr valign="top">
@@ -35,8 +35,8 @@
         </table>
 
         <h3>Link Event Tracking</h3>
-        <p>Use the following to track links via <a href="https://support.google.com/analytics/answer/1033068?hl=en">Google Anlaytics Event</a> tracking. You can customize the category but the Action will always be the link destination and the label will be the page the link was clicked on.</p>
-        <?
+        <p>Use the following to track links via <a href="https://support.google.com/analytics/answer/1033068?hl=en">Google Analytics Event</a> tracking. You can customize the category but the Action will always be the link destination and the label will be the page the link was clicked on.</p>
+        <?php
         $mcGAEvents = array_replace_recursive(
             array(
                 'email' => array(
@@ -64,37 +64,37 @@
             </tr>
             <tr valign="top">
                 <td>
-                    <input type="checkbox" id="mcga-email-link" name="mc_ga_events[email][status]" value="1" <?=($mcGAEvents['email']['status'] ? 'checked="checked"' : null);?> />
+                    <input type="checkbox" id="mcga-email-link" name="mc_ga_events[email][status]" value="1" <?php echo ($mcGAEvents['email']['status'] ? 'checked="checked"' : null);?> />
                     <label for="mcga-email-link">Email</label>
                 </td>
-                <td><input type="text" placeholder="MailTo" name="mc_ga_events[email][category]" value="<?=$mcGAEvents['email']['category'];?>" /></td>
+                <td><input type="text" placeholder="MailTo" name="mc_ga_events[email][category]" value="<?php echo $mcGAEvents['email']['category'];?>" /></td>
                 <td></td>
             </tr>
             <tr valign="top">
                 <td>
-                    <input type="checkbox" id="mcga-doc-link" name="mc_ga_events[download][status]" value="1" <?=($mcGAEvents['download']['status'] ? 'checked="checked"' : null);?> />
+                    <input type="checkbox" id="mcga-doc-link" name="mc_ga_events[download][status]" value="1" <?php echo ($mcGAEvents['download']['status'] ? 'checked="checked"' : null);?> />
                     <label for="mcga-doc-link">File</label>
                 </td>
                 <td>
-                    <input type="text" placeholder="Downloads-{EXT}" name="mc_ga_events[download][category]" value="<?=$mcGAEvents['download']['category'];?>" /><br/>
+                    <input type="text" placeholder="Downloads-{EXT}" name="mc_ga_events[download][category]" value="<?php echo $mcGAEvents['download']['category'];?>" /><br/>
                     <em>use the token "{EXT}" for<br/> the file extension.</em>
                 </td>
                 <td class="other">
-                    <input type="text" placeholder="doc|docx|xls|xlsx|ppt|pptx|jpg|png|gif|pdf|zip|txt|mov" name="mc_ga_events[download][extensions]" value="<?=$mcGAEvents['download']['extensions'];?>" /><br/>
+                    <input type="text" placeholder="doc|docx|xls|xlsx|ppt|pptx|jpg|png|gif|pdf|zip|txt|mov" name="mc_ga_events[download][extensions]" value="<?php echo $mcGAEvents['download']['extensions'];?>" /><br/>
                     <em>File extensions to track (pipe or comma delimited).<br/>
                     <strong>Default:</strong> doc|docx|xls|xlsx|ppt|pptx|jpg|png|gif|pdf|zip|txt|mov</em>
                 </td>
             </tr>
             <tr valign="top">
                 <td>
-                    <input type="checkbox" id="mcga-external-link" name="mc_ga_events[external][status]" value="1" <?=($mcGAEvents['external']['status'] ? 'checked="checked"' : null);?> />
+                    <input type="checkbox" id="mcga-external-link" name="mc_ga_events[external][status]" value="1" <?php echo ($mcGAEvents['external']['status'] ? 'checked="checked"' : null);?> />
                     <label for="mcga-external-link">External</label>
                 </td>
-                <td><input type="text" placeholder="External" name="mc_ga_events[external][category]" value="<?=$mcGAEvents['external']['category'];?>" /></td>
+                <td><input type="text" placeholder="External" name="mc_ga_events[external][category]" value="<?php echo $mcGAEvents['external']['category'];?>" /></td>
                 <td></td>
             </tr>
         </table>
 
-        <? submit_button(); ?>
+        <?php submit_button(); ?>
     </form>
 </div>

--- a/templates/tracking-code.tpl
+++ b/templates/tracking-code.tpl
@@ -4,8 +4,8 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '<?=$mcGATrackingID;?>', 'auto', <?=json_encode( $mcGACreateOptions );?>);
+  ga('create', '<?php echo $mcGATrackingID;?>', 'auto', <?php echo json_encode( $mcGACreateOptions );?>);
   ga('send', 'pageview');
 
-  var mcGATrackingParams = <?=json_encode( $mcGATrackingParams ); ?>;
+  var mcGATrackingParams = <?php echo json_encode( $mcGATrackingParams ); ?>;
 </script>


### PR DESCRIPTION
When using this plugin, my version/configuration of PHP (7.4.12) had trouble parsing the PHP shorthand tags. Since it's also not in line with the WordPress Coding Standards (https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#no-shorthand-php-tags), I'm submitting this PR with shorthand tags updated to full tags.

There was also a small typo on the Admin Settings page that is fixed in this PR.

Thanks!